### PR TITLE
v6.10.0 "Portability Guardrails"

### DIFF
--- a/VERSION.md
+++ b/VERSION.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v6.10.0 - Portability Guardrails
+
 ### Fixed
 
 - Added fail-closed potfile validation before normal Hashcat execution.

--- a/hash-cracker.sh
+++ b/hash-cracker.sh
@@ -53,7 +53,7 @@ function banner_center_line() {
 }
 
 function release_version_text() {
-    printf '%s' 'v6.9.0 "Private Artifact Lifecycle"'
+    printf '%s' 'v6.10.0 "Portability Guardrails"'
 }
 
 function release_label_text() {

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -1420,8 +1420,8 @@ run_case common_substring_helper_failure bash -lc "COMMON_SUBSTR_FAIL=1 ./hash-c
 assert_rc_eq 1
 assert_contains "Common-substring helper preprocessing failed."
 assert_not_contains "Substring processing done"
-if ! grep -Fq '"release": "v6.9.0 \"Private Artifact Lifecycle\""' "$PRESET_STATS_EXPORT_PATH"; then
-    fail_with_log "preset stats export missing v6.9.0 release marker" "$PRESET_STATS_EXPORT_PATH"
+if ! grep -Fq '"release": "v6.10.0 \"Portability Guardrails\""' "$PRESET_STATS_EXPORT_PATH"; then
+    fail_with_log "preset stats export missing v6.10.0 release marker" "$PRESET_STATS_EXPORT_PATH"
 fi
 
 echo "[smoke] invalid --job selection fails clearly"


### PR DESCRIPTION
## Summary

Prepare the merged portability and campaign-state work for the `v6.10.0` release.

## Changes

- Update the runtime banner and campaign/statistics release marker to `v6.10.0 "Portability Guardrails"`.
- Move the accumulated Unreleased notes under the new release heading.

## Validation

- `make test-smoke`
- `make test-campaign`
- `make lint`
- Pinned shfmt v3.8.0 format check
- Bash coverage: 100% lines/functions; baseline satisfied
- Python coverage: 54.13%; baseline satisfied
- Bash syntax and diff checks

Real Apple Silicon validation for options 10, 11, and 17 remains a documented follow-up; Intel macOS is unsupported.
